### PR TITLE
Small i18n fixes

### DIFF
--- a/core/assets/i18n/bundle.properties
+++ b/core/assets/i18n/bundle.properties
@@ -123,9 +123,11 @@ dVersionHere = here
 
 dTuTitle = Texture unpacker
 dTuTitleSuccess = Successfully unpacked
+dTuDescription = Unpacks a texture atlas into individual image files
 dTuAtlasPath = Atlas path
 dTuOutputDir = Output directory
 dTuOpenOutputDir = Open output directory
+dTuProcess = Process
 
 dPackPlacing = Place new pack:
 dPackPlaceAbove = Above current
@@ -161,6 +163,7 @@ psPaddingY = Padding Y
 psWrapX = Wrap X
 psWrapY = Wrap Y
 psJpegQuality = Jpeg quality
+psScaleFactors = Scale factors
 
 psUseFastAlgorithm = Use fast algorithm
 psEdgePadding = Edge padding
@@ -221,4 +224,6 @@ canvasInfoTtZoom = Zoom
 canvasInfoTtPages = Current page / total pages
 canvasInfoTtPageDimen = Page texture dimensions
 canvasInfoTtPageFileSize = Page texture file size
+atlasPreviewNextPage = Next page
+atlasPreviewPrevPage = Previous page
 atlasPreviewNoPageMsg = Nothing to show.\nPack atlas to see pages.

--- a/core/assets/i18n/bundle.properties
+++ b/core/assets/i18n/bundle.properties
@@ -95,7 +95,7 @@ dAboutVersion = version
 dAboutAuthors = Authors:
 dAboutLinks = Links:
 dAboutAChekulaev = Anton Chekulaev
-dAboutAChekulaevDesc lead developer, graphics
+dAboutAChekulaevDesc = lead developer, graphics
 dAboutARibon = Aurelien Ribon
 dAboutARibonDesc = author of original application
 dAboutTeraFog = TeraFog Studios

--- a/core/assets/i18n/bundle_de.properties
+++ b/core/assets/i18n/bundle_de.properties
@@ -86,7 +86,7 @@ dAboutVersion = Version
 dAboutAuthors = Autoren:
 dAboutLinks = Links:
 dAboutAChekulaev = Anton Chekulaev
-dAboutAChekulaevDesc Haupt-Entwickler, Grafik
+dAboutAChekulaevDesc = Haupt-Entwickler, Grafik
 dAboutARibon = Aurelien Ribon
 dAboutARibonDesc = Autor der ursprünglichen Anwendung
 dAboutTeraFog = TeraFog Studios
@@ -131,8 +131,8 @@ dSfNoSuffix = kein Suffix
 dSfErrNoEntries = Es sollte zumindest einen Eintrag geben
 dSfErrNonUniqueSuffixes = Suffixe müssen einzigartig sein
 
-dPbTitle = Preview background
-dPbChangeBackground = Change background
+dPbTitle = Hintergrund Vorschau
+dPbChangeBackground = Hintergrund ändern
 
 
 # Global settings panel

--- a/core/assets/i18n/bundle_de.properties
+++ b/core/assets/i18n/bundle_de.properties
@@ -114,9 +114,11 @@ dVersionHere = hier
 
 dTuTitle = Texturen entpacken
 dTuTitleSuccess = Erfolgreich entpackt
+dTuDescription = Entpackt einen Atlas in einzelne Grafik-Dateien
 dTuAtlasPath = Atlas Pfad
 dTuOutputDir = Ausgabeverzeichnis
 dTuOpenOutputDir = Ausgabeverzeichnis öffnen
+dTuProcess = Verarbeiten
 
 dPackPlacing = Neues Pack einfügen:
 dPackPlaceAbove = Über aktuellem
@@ -152,6 +154,7 @@ psPaddingY = Abstand vertikal
 psWrapX = Wrap-Modus horizontal
 psWrapY = Wrap-Modus vertikal
 psJpegQuality = Jpeg Qualität
+psScaleFactors = Skalierungs-Faktoren
 
 psUseFastAlgorithm = Schneller Algorithmus
 psEdgePadding = Außenkantenabstand
@@ -212,4 +215,6 @@ canvasInfoTtZoom = Zoom
 canvasInfoTtPages = Aktuelle Seite / Seiten gesamt
 canvasInfoTtPageDimen = Texturseiten-Dimensionen
 canvasInfoTtPageFileSize = Texturseiten-Dateigröße
+atlasPreviewNextPage = Seite vor
+atlasPreviewPrevPage = Seite zurück
 atlasPreviewNoPageMsg = Nichts zu zeigen.\nPacke Atlas um Seiten anzuzeigen.

--- a/core/assets/i18n/bundle_ru.properties
+++ b/core/assets/i18n/bundle_ru.properties
@@ -87,7 +87,7 @@ dAboutVersion = версия
 dAboutAuthors = Авторы:
 dAboutLinks = Ссылки:
 dAboutAChekulaev = Антон Чекулаев
-dAboutAChekulaevDesc разработчик, художник
+dAboutAChekulaevDesc = разработчик, художник
 dAboutARibon = Орельен Рибон
 dAboutARibonDesc = автор оригинального проекта
 dAboutTeraFog = TeraFog Studios

--- a/core/assets/lml/panePackSettings.lml
+++ b/core/assets/lml/panePackSettings.lml
@@ -146,7 +146,7 @@
                                 tooltip="@psTtWrapY"/>
                     </:item>
 
-                    <:item title="Scale factors">
+                    <:item title="@psScaleFactors">
                         <expandedittextbutton
                                 id="eetbScaleFactors"
                                 change="onScalesBtnClick"

--- a/core/assets/lml/textureunpacker/dialogTextureUnpacker.lml
+++ b/core/assets/lml/textureunpacker/dialogTextureUnpacker.lml
@@ -7,7 +7,7 @@
         closeonescape="true">
     <vistable minwidth="360" onecolumn="true">
 
-        <label wrap="true" growx="true" color="light-grey" labelalignment="left">Unpacks a texture atlas into individual image files</label>
+        <label wrap="true" growx="true" color="light-grey" labelalignment="left">@dTuDescription</label>
 
         <:row padtop="4"/>
 
@@ -49,7 +49,7 @@
 
         <:row padtop="4"/>
 
-        <textbutton change="launchUnpackProcess" text="Process" align="right" tablepadleft="16" tablepadright="16"/>
+        <textbutton change="launchUnpackProcess" text="@dTuProcess" align="right" tablepadleft="16" tablepadright="16"/>
 
     </vistable>
 </visdialog>

--- a/core/src/com/crashinvaders/texturepackergui/views/canvas/Canvas.java
+++ b/core/src/com/crashinvaders/texturepackergui/views/canvas/Canvas.java
@@ -68,7 +68,8 @@ public class Canvas extends Stack {
 
 			// Page buttons
 			{
-				btnNextPage = new VisImageTextButton("Next page", "default");
+				String text = App.inst().getI18n().get("atlasPreviewNextPage");
+				btnNextPage = new VisImageTextButton(text, "default");
 				{
 					btnNextPage.addListener(new ChangeListener() {
                         @Override
@@ -88,7 +89,8 @@ public class Canvas extends Stack {
 					btnNextPage.getLabelCell().padBottom(2f);
 				}
 
-				btnPrevPage = new VisImageTextButton("Previous page", "default");
+				text = App.inst().getI18n().get("atlasPreviewPrevPage");
+				btnPrevPage = new VisImageTextButton(text, "default");
 				{
 					btnPrevPage.addListener(new ChangeListener() {
 						@Override


### PR DESCRIPTION
Made a few hardcoded strings translatable.

English and german is done. I don't know Russian so bundle_ru.properties needs the new additions translated still:
- dTuDescription
- dTuProcess
- psScaleFactors
- atlasPreviewNextPage
- atlasPreviewPrevPage