### PR TITLE
File chooser default settings do not remember lat opened directory

### DIFF
--- a/core/src/com/crashinvaders/texturepackergui/App.java
+++ b/core/src/com/crashinvaders/texturepackergui/App.java
@@ -78,6 +78,7 @@ public class App implements ApplicationListener {
 
         initiateContext();
 
+        FileChooser.setSaveLastDirectory(true);
         FileChooser.setDefaultPrefsName("file_chooser.xml");
 
         // Uncomment to update project's LML DTD schema


### PR DESCRIPTION
Added FileChooser initialization to remember the last opened directory across application sessions.