### PR TITLE
PNG8 improvements

### DIFF
--- a/core/src/com/crashinvaders/texturepackergui/controllers/packing/processors/Png8CompressingProcessor.java
+++ b/core/src/com/crashinvaders/texturepackergui/controllers/packing/processors/Png8CompressingProcessor.java
@@ -9,7 +9,6 @@ import com.crashinvaders.texturepackergui.controllers.model.ProjectModel;
 import com.crashinvaders.texturepackergui.controllers.model.compression.Png8CompressionModel;
 import com.crashinvaders.texturepackergui.controllers.model.filetype.PngFileTypeModel;
 import com.crashinvaders.texturepackergui.utils.PNG8;
-import com.crashinvaders.texturepackergui.utils.PaletteReducer;
 import com.crashinvaders.texturepackergui.utils.packprocessing.PackProcessingNode;
 import com.crashinvaders.texturepackergui.utils.packprocessing.PackProcessor;
 
@@ -44,8 +43,7 @@ public class Png8CompressingProcessor implements PackProcessor {
                     long preCompressedSize = page.textureFile.length();
                     pm = new Pixmap(page.textureFile);
                     png8.setCompression(compModel.getLevel());
-                    png8.palette = new PaletteReducer(pm, compModel.getThreshold());
-                    png8.write(page.textureFile, pm, false, compModel.isDithering());
+                    png8.writePrecisely(page.textureFile, pm, compModel.isDithering(), compModel.getThreshold());
                     long postCompressedSize = page.textureFile.length();
                     float pageCompression = ((postCompressedSize-preCompressedSize) / (float)preCompressedSize);
                     compressionRateSum += pageCompression;

--- a/core/src/com/crashinvaders/texturepackergui/utils/PNG8.java
+++ b/core/src/com/crashinvaders/texturepackergui/utils/PNG8.java
@@ -7,13 +7,13 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.ByteArray;
 import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.IntIntMap;
 import com.badlogic.gdx.utils.StreamUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedOutputStream;
 import java.util.zip.Deflater;
@@ -26,11 +26,15 @@ import static com.crashinvaders.texturepackergui.utils.PaletteReducer.randomXi;
  * {@link PaletteReducer} object that is allowed to be null and can be reused. The methods
  * {@link PaletteReducer#exact(Color[])} or {@link PaletteReducer#analyze(Pixmap)} can be used to make the target
  * palette match a specific set of colors or the colors in an existing image. You can use
- * {@link PaletteReducer#setDitherStrength(float)} to reduce (or maybe increase) dither strength; the dithering
- * algorithm used here is a modified version of the algorithm presented in "Simple gradient-based error-diffusion
- * method" by Xaingyu Y. Hu in the Journal of Electronic Imaging, 2016. This algorithm uses pseudo-randomly-generated
- * noise (it is deterministic, and is seeded using the color information) to adjust Floyd-Steinberg dithering. It yields
+ * {@link PaletteReducer#setDitherStrength(float)} to reduce (or increase) dither strength; the dithering algorithm used
+ * here is a modified version of the algorithm presented in "Simple gradient-based error-diffusion method" by Xaingyu Y.
+ * Hu in the Journal of Electronic Imaging, 2016. This algorithm uses pseudo-randomly-generated noise (it is
+ * deterministic, and is seeded using the color information) to adjust Floyd-Steinberg dithering. It yields
  * surprisingly non-random-looking dithers, but still manages to break up artificial patterns most of the time.
+ * Note that much of the time you will want to use {@link #writePrecisely(FileHandle, Pixmap, boolean)} instead of
+ * {@link #write(FileHandle, Pixmap, boolean, boolean)}, since writePrecisely will attempt to reproduce the exact colors
+ * if there are 256 colors or less in the Pixmap, and will automatically change to calling write() if there are more
+ * than 256 colors.
  * <br>
  * From LibGDX in the class PixmapIO, with modifications to support indexed-mode files, dithering, and other features.
  * <pre>
@@ -76,81 +80,6 @@ public class PNG8 implements Disposable {
     private int lastLineLen;
 
     public PaletteReducer palette;
-//    /**
-//     * A lookup table from 32 possible levels in the red channel to 6 possible values in the red channel.
-//     */
-//    private static final int[]
-//            redLUT =   {
-//            0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE00003A,
-//            0xFE00003A, 0xFE00003A, 0xFE00003A, 0xFE00003A, 0xFE00003A, 0xFE00003A, 0xFE000074, 0xFE000074,
-//            0xFE000074, 0xFE000074, 0xFE000074, 0xFE0000B6, 0xFE0000B6, 0xFE0000B6, 0xFE0000B6, 0xFE0000B6,
-//            0xFE0000E0, 0xFE0000E0, 0xFE0000E0, 0xFE0000E0, 0xFE0000FF, 0xFE0000FF, 0xFE0000FF, 0xFE0000FF,};
-//    /**
-//     * The 6 possible values that can be used in the red channel with {@link #redLUT}.
-//     */
-//    private static final byte[] redPossibleLUT = {0x00, 0x3A, 0x74, (byte)0xB6, (byte)0xE0, (byte)0xFF};
-//
-//    /**
-//     * A lookup table from 32 possible levels in the green channel to 7 possible values in the green channel.
-//     */
-//    private static final int[]
-//            greenLUT = {
-//            0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE003800,
-//            0xFE003800, 0xFE003800, 0xFE003800, 0xFE003800, 0xFE006000, 0xFE006000, 0xFE006000, 0xFE006000,
-//            0xFE006000, 0xFE009800, 0xFE009800, 0xFE009800, 0xFE009800, 0xFE00C400, 0xFE00C400, 0xFE00C400,
-//            0xFE00C400, 0xFE00EE00, 0xFE00EE00, 0xFE00EE00, 0xFE00EE00, 0xFE00FF00, 0xFE00FF00, 0xFE00FF00,};
-//    /**
-//     * The 7 possible values that can be used in the green channel with {@link #greenLUT}.
-//     */
-//    private static final byte[] greenPossibleLUT = {0x00, 0x38, 0x60, (byte)0x98, (byte)0xC4, (byte)0xEE, (byte)0xFF};
-//    /**
-//     * A lookup table from 32 possible levels in the blue channel to 6 possible values in the blue channel.
-//     */
-//    private static final int[]
-//            blueLUT =  {
-//            0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE000000, 0xFE380000,
-//            0xFE380000, 0xFE380000, 0xFE380000, 0xFE380000, 0xFE380000, 0xFE760000, 0xFE760000, 0xFE760000,
-//            0xFE760000, 0xFE760000, 0xFE760000, 0xFEAC0000, 0xFEAC0000, 0xFEAC0000, 0xFEAC0000, 0xFEAC0000,
-//            0xFEEA0000, 0xFEEA0000, 0xFEEA0000, 0xFEEA0000, 0xFEFF0000, 0xFEFF0000, 0xFEFF0000, 0xFEFF0000,};
-//    /**
-//     * The 6 possible values that can be used in the blue channel with {@link #blueLUT}.
-//     */
-//    private static final byte[] bluePossibleLUT = {0x00, 0x38, 0x76, (byte)0xAC, (byte)0xEA, (byte)0xFF};
-
-//    public void build253Palette()
-//    {
-//        Arrays.fill(paletteArray, 0);
-//        int i = 0, j, rl, gl, bl, rMin, rMax=0, gMin, gMax, bMin, bMax;
-//        for (int r = 0; r < 6; r++) {
-//            rl = redPossibleLUT[r] & 0xFF;
-//            rMin=rMax;
-//            for (j = rMin; j < 32 && (redLUT[j] & 0xFF) == rl; j++) { }
-//            rMax=j;
-//            gMax = 0;
-//            for (int g = 0; g < 7; g++) {
-//                gl = greenPossibleLUT[g] & 0xFF;
-//                gMin=gMax;
-//                for (j = gMin; j < 32 && (greenLUT[j] >> 8 & 0xFF) == gl; j++) { }
-//                gMax=j;
-//                bMax = 0;
-//                for (int b = 0; b < 6; b++) {
-//                    bl = bluePossibleLUT[b] & 0xFF;
-//                    bMin=bMax;
-//                    for (j = bMin; j < 32 && (blueLUT[j] >> 16 & 0xFF) == bl; j++) { }
-//                    bMax=j;
-//                    paletteArray[++i] =
-//                            (rl << 24
-//                                    | (gl << 16 & 0xFF0000)
-//                                    | (bl << 8 & 0xFF00) | 0xFE);
-//                    for (int rm = rMin; rm < rMax; rm++) {
-//                        for (int gm = gMin; gm < gMax; gm++) {
-//                            Arrays.fill(paletteMapping, (rm << 10) + (gm << 5) + (bMin), (rm << 10) + (gm << 5) + (bMax), (byte)i);
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
 
     public PNG8() {
         this(128 * 128);
@@ -223,13 +152,36 @@ public class PNG8 implements Disposable {
             StreamUtils.closeQuietly(output);
         }
     }
+    /**
+     * Writes the pixmap to the stream without closing the stream, optionally computing an 8-bit palette from the given
+     * Pixmap. If {@link #palette} is null (the default unless it has been assigned a PaletteReducer value), this will
+     * compute a palette from the given Pixmap regardless of computePalette. Uses the given threshold while analyzing
+     * the palette if this needs to compute a palette; threshold values can be as low as 0 to try to use as many colors
+     * as possible (prefer {@link  #writePrecisely(FileHandle, Pixmap, boolean, int)} for that, though) and can range up
+     * to very high numbers if very few colors should be used; usually threshold is from 100 to 800. Optionally dithers
+     * the result if {@code dither} is true.
+     * @param file a FileHandle that must be writable, and will have the given Pixmap written as a PNG-8 image
+     * @param pixmap a Pixmap to write to the given output stream
+     * @param computePalette if true, this will analyze the Pixmap and use the most common colors
+     * @param dither true if this should dither colors that can't be represented exactly
+     * @param threshold the analysis threshold to use if computePalette is true (min 0, practical max is over 100000)
+     * @throws IOException if file writing fails for any reason
+     */
+    public void write (FileHandle file, Pixmap pixmap, boolean computePalette, boolean dither, int threshold) throws IOException {
+        OutputStream output = file.write(false);
+        try {
+            write(output, pixmap, computePalette, dither, threshold);
+        } finally {
+            StreamUtils.closeQuietly(output);
+        }
+    }
 
     /** Writes the pixmap to the stream without closing the stream and computes an 8-bit palette from the Pixmap.
      * @param output an OutputStream that will not be closed
      * @param pixmap a Pixmap to write to the given output stream
      */
     public void write (OutputStream output, Pixmap pixmap) throws IOException {
-        write(output, pixmap, true);
+        writePrecisely(output, pixmap, true);
     }
 
     /**
@@ -242,7 +194,10 @@ public class PNG8 implements Disposable {
      */
     public void write (OutputStream output, Pixmap pixmap, boolean computePalette) throws IOException
     {
-        write(output, pixmap, computePalette, true);
+        if(computePalette)
+            writePrecisely(output, pixmap, true);
+        else
+            write(output, pixmap, false, true);
     }
 
     /**
@@ -256,23 +211,241 @@ public class PNG8 implements Disposable {
      */
     public void write (OutputStream output, Pixmap pixmap, boolean computePalette, boolean dither) throws IOException
     {
-        if(dither) writeDithered(output, pixmap, computePalette);
-        else writeSolid(output, pixmap, computePalette);
+        write(output, pixmap, computePalette, dither, 400);
     }
-    private void writeSolid (OutputStream output, Pixmap pixmap, boolean computePalette) throws IOException{
-        DeflaterOutputStream deflaterOutput = new DeflaterOutputStream(buffer, deflater);
+    /**
+     * Writes the pixmap to the stream without closing the stream, optionally computing an 8-bit palette from the given
+     * Pixmap. If {@link #palette} is null (the default unless it has been assigned a PaletteReducer value), this will
+     * compute a palette from the given Pixmap regardless of computePalette.
+     * @param output an OutputStream that will not be closed
+     * @param pixmap a Pixmap to write to the given output stream
+     * @param computePalette if true, this will analyze the Pixmap and use the most common colors
+     * @param dither true if this should dither colors that can't be represented exactly
+     * @param threshold the analysis threshold to use if computePalette is true (min 0, practical max is over 100000)
+     */
+    public void write (OutputStream output, Pixmap pixmap, boolean computePalette, boolean dither, int threshold) throws IOException
+    {
         if(palette == null)
         {
-            palette = new PaletteReducer(pixmap);
+            palette = new PaletteReducer(pixmap, threshold);
         }
         else if(computePalette)
         {
-            palette.analyze(pixmap);
+            palette.analyze(pixmap, threshold);
         }
+
+        if(dither) writeDithered(output, pixmap);
+        else writeSolid(output, pixmap);
+    }
+    /**
+     * Attempts to write the given Pixmap exactly as a PNG-8 image to file; this attempt will only succeed if there
+     * are no more than 256 colors in the Pixmap (treating all partially transparent colors as fully transparent).
+     * If the attempt fails, this falls back to calling {@link #write(FileHandle, Pixmap, boolean, boolean)}, which
+     * can dither the image to use no more than 255 colors (plus fully transparent) based on ditherFallback and will
+     * always analyze the Pixmap to get an accurate-enough palette. All other write() methods in this class will
+     * reduce the color depth somewhat, but as long as the color count stays at 256 or less, this will keep the
+     * non-alpha components of colors exactly.
+     * @param file a FileHandle that must be writable, and will have the given Pixmap written as a PNG-8 image
+     * @param pixmap a Pixmap to write to the given output stream
+     * @param ditherFallback if the Pixmap contains too many colors, this determines whether it will dither the output
+     * @throws IOException if file writing fails for any reason
+     */
+    public void writePrecisely (FileHandle file, Pixmap pixmap, boolean ditherFallback) throws IOException {
+        writePrecisely(file, pixmap, ditherFallback, 400);
+    }
+    /**
+     * Attempts to write the given Pixmap exactly as a PNG-8 image to file; this attempt will only succeed if there
+     * are no more than 256 colors in the Pixmap (treating all partially transparent colors as fully transparent).
+     * If the attempt fails, this falls back to calling {@link #write(FileHandle, Pixmap, boolean, boolean)}, which
+     * can dither the image to use no more than 255 colors (plus fully transparent) based on ditherFallback and will
+     * always analyze the Pixmap to get an accurate-enough palette, using the given threshold for analysis (which is
+     * typically between 1 and 1000, and most often near 200-400). All other write() methods in this class will
+     * reduce the color depth somewhat, but as long as the color count stays at 256 or less, this will keep the
+     * non-alpha components of colors exactly.
+     * @param file a FileHandle that must be writable, and will have the given Pixmap written as a PNG-8 image
+     * @param pixmap a Pixmap to write to the given output stream
+     * @param ditherFallback if the Pixmap contains too many colors, this determines whether it will dither the output
+     * @param threshold the analysis threshold to use if there are too many colors (min 0, practical max is over 100000)
+     * @throws IOException if file writing fails for any reason
+     */
+    public void writePrecisely (FileHandle file, Pixmap pixmap, boolean ditherFallback, int threshold) throws IOException {
+        OutputStream output = file.write(false);
+        try {
+            writePrecisely(output, pixmap, ditherFallback, threshold);
+        } finally {
+            StreamUtils.closeQuietly(output);
+        }
+    }
+
+    /**
+     * Attempts to write the given Pixmap exactly as a PNG-8 image to output; this attempt will only succeed if there
+     * are no more than 256 colors in the Pixmap (treating all partially transparent colors as fully transparent).
+     * If the attempt fails, this falls back to calling {@link #write(OutputStream, Pixmap, boolean, boolean)}, which
+     * can dither the image to use no more than 255 colors (plus fully transparent) based on ditherFallback and will
+     * always analyze the Pixmap to get an accurate-enough palette. All other write() methods in this class will
+     * reduce the color depth somewhat, but as long as the color count stays at 256 or less, this will keep the
+     * non-alpha components of colors exactly.
+     * @param output an OutputStream that will not be closed
+     * @param pixmap a Pixmap to write to the given output stream
+     * @param ditherFallback if the Pixmap contains too many colors, this determines whether it will dither the output
+     * @throws IOException if OutputStream things fail for any reason
+     */
+    public void writePrecisely(OutputStream output, Pixmap pixmap, boolean ditherFallback) throws IOException {
+        writePrecisely(output, pixmap, ditherFallback, 400);
+    }
+
+    /**
+     * Attempts to write the given Pixmap exactly as a PNG-8 image to output; this attempt will only succeed if there
+     * are no more than 256 colors in the Pixmap (treating all partially transparent colors as fully transparent).
+     * If the attempt fails, this falls back to calling {@link #write(OutputStream, Pixmap, boolean, boolean)}, which
+     * can dither the image to use no more than 255 colors (plus fully transparent) based on ditherFallback and will
+     * always analyze the Pixmap to get an accurate-enough palette, using the given threshold for analysis (which is
+     * typically between 1 and 1000, and most often near 200-400). All other write() methods in this class will
+     * reduce the color depth somewhat, but as long as the color count stays at 256 or less, this will keep the
+     * non-alpha components of colors exactly.
+     * @param output an OutputStream that will not be closed
+     * @param pixmap a Pixmap to write to the given output stream
+     * @param ditherFallback if the Pixmap contains too many colors, this determines whether it will dither the output
+     * @param threshold the analysis threshold to use if there are too many colors (min 0, practical max is over 100000)
+     * @throws IOException if OutputStream things fail for any reason
+     */
+    public void writePrecisely(OutputStream output, Pixmap pixmap, boolean ditherFallback, int threshold) throws IOException {
+        IntIntMap colorToIndex = new IntIntMap(256);
+        colorToIndex.put(0, 0);
+        int color;
+        int hasTransparent = 0;
+        final int w = pixmap.getWidth(), h = pixmap.getHeight();
+        for (int y = 0; y < h; y++) {
+            int py = flipY ? (h - y - 1) : y;
+            for (int px = 0; px < w; px++) {
+                color = pixmap.getPixel(px, py);
+                if((color & 0xFE) != 0xFE) {
+                    if(hasTransparent == 0 && colorToIndex.size >= 256)
+                    {
+                        write(output, pixmap, true, ditherFallback, threshold);
+                        return;
+                    }
+                    hasTransparent = 1;
+                }
+                else if(!colorToIndex.containsKey(color))
+                {
+                    colorToIndex.put(color, colorToIndex.size & 255);
+                    if(colorToIndex.size == 257 && hasTransparent == 0)
+                    {
+                        colorToIndex.remove(0, 0);
+                    }
+                    if(colorToIndex.size > 256)
+                    {
+                        write(output, pixmap, true, ditherFallback, threshold);
+                        return;
+                    }
+                }
+            }
+        }
+        int[] paletteArray = new int[colorToIndex.size];
+        for(IntIntMap.Entry ent : colorToIndex)
+        {
+            paletteArray[ent.value] = ent.key;
+        }
+        DeflaterOutputStream deflaterOutput = new DeflaterOutputStream(buffer, deflater);
+        DataOutputStream dataOutput = new DataOutputStream(output);
+        dataOutput.write(SIGNATURE);
+
+        buffer.writeInt(IHDR);
+        buffer.writeInt(pixmap.getWidth());
+        buffer.writeInt(pixmap.getHeight());
+        buffer.writeByte(8); // 8 bits per component.
+        buffer.writeByte(COLOR_INDEXED);
+        buffer.writeByte(COMPRESSION_DEFLATE);
+        buffer.writeByte(FILTER_NONE);
+        buffer.writeByte(INTERLACE_NONE);
+        buffer.endChunk(dataOutput);
+
+        buffer.writeInt(PLTE);
+        for (int i = 0; i < paletteArray.length; i++) {
+            int p = paletteArray[i];
+            buffer.write(p>>>24);
+            buffer.write(p>>>16);
+            buffer.write(p>>>8);
+        }
+        buffer.endChunk(dataOutput);
+
+        if(hasTransparent == 1) {
+            buffer.writeInt(TRNS);
+            buffer.write(0);
+            buffer.endChunk(dataOutput);
+        }
+        buffer.writeInt(IDAT);
+        deflater.reset();
+
+        int lineLen = pixmap.getWidth();
+        byte[] lineOut, curLine, prevLine;
+        if (lineOutBytes == null) {
+            lineOut = (lineOutBytes = new ByteArray(lineLen)).items;
+            curLine = (curLineBytes = new ByteArray(lineLen)).items;
+            prevLine = (prevLineBytes = new ByteArray(lineLen)).items;
+        } else {
+            lineOut = lineOutBytes.ensureCapacity(lineLen);
+            curLine = curLineBytes.ensureCapacity(lineLen);
+            prevLine = prevLineBytes.ensureCapacity(lineLen);
+            for (int i = 0, n = lastLineLen; i < n; i++)
+            {
+                prevLine[i] = 0;
+            }
+        }
+
+        lastLineLen = lineLen;
+
+        for (int y = 0; y < h; y++) {
+            int py = flipY ? (h - y - 1) : y;
+            for (int px = 0; px < w; px++) {
+                color = pixmap.getPixel(px, py);
+                curLine[px] = (byte) colorToIndex.get(color, 0);
+            }
+
+            lineOut[0] = (byte)(curLine[0] - prevLine[0]);
+
+            //Paeth
+            for (int x = 1; x < lineLen; x++) {
+                int a = curLine[x - 1] & 0xff;
+                int b = prevLine[x] & 0xff;
+                int c = prevLine[x - 1] & 0xff;
+                int p = a + b - c;
+                int pa = p - a;
+                if (pa < 0) pa = -pa;
+                int pb = p - b;
+                if (pb < 0) pb = -pb;
+                int pc = p - c;
+                if (pc < 0) pc = -pc;
+                if (pa <= pb && pa <= pc)
+                    c = a;
+                else if (pb <= pc)
+                    c = b;
+                lineOut[x] = (byte)(curLine[x] - c);
+            }
+
+            deflaterOutput.write(PAETH);
+            deflaterOutput.write(lineOut, 0, lineLen);
+
+            byte[] temp = curLine;
+            curLine = prevLine;
+            prevLine = temp;
+        }
+        deflaterOutput.finish();
+        buffer.endChunk(dataOutput);
+
+        buffer.writeInt(IEND);
+        buffer.endChunk(dataOutput);
+
+        output.flush();
+
+    }
+
+    private void writeSolid (OutputStream output, Pixmap pixmap) throws IOException{
         final int[] paletteArray = palette.paletteArray;
         final byte[] paletteMapping = palette.paletteMapping;
 
-
+        DeflaterOutputStream deflaterOutput = new DeflaterOutputStream(buffer, deflater);
         DataOutputStream dataOutput = new DataOutputStream(output);
         dataOutput.write(SIGNATURE);
 
@@ -323,10 +496,9 @@ public class PNG8 implements Disposable {
 
         lastLineLen = lineLen;
 
-        ByteBuffer pixels = pixmap.getPixels();
-        int oldPosition = pixels.position(), color;
-        final int w = pixmap.getWidth();
-        for (int y = 0, h = pixmap.getHeight(); y < h; y++) {
+        int color;
+        final int w = pixmap.getWidth(), h = pixmap.getHeight();
+        for (int y = 0; y < h; y++) {
             int py = flipY ? (h - y - 1) : y;
             for (int px = 0; px < w; px++) {
                 color = pixmap.getPixel(px, py);
@@ -370,7 +542,6 @@ public class PNG8 implements Disposable {
             curLine = prevLine;
             prevLine = temp;
         }
-        pixels.position(oldPosition);
         deflaterOutput.finish();
         buffer.endChunk(dataOutput);
 
@@ -380,16 +551,8 @@ public class PNG8 implements Disposable {
         output.flush();
     }
 
-    private void writeDithered (OutputStream output, Pixmap pixmap, boolean computePalette) throws IOException{
+    private void writeDithered (OutputStream output, Pixmap pixmap) throws IOException{
         DeflaterOutputStream deflaterOutput = new DeflaterOutputStream(buffer, deflater);
-        if(palette == null)
-        {
-            palette = new PaletteReducer(pixmap);
-        }
-        else if(computePalette)
-        {
-            palette.analyze(pixmap);
-        }
         final int[] paletteArray = palette.paletteArray;
         final byte[] paletteMapping = palette.paletteMapping;
 

--- a/core/src/com/crashinvaders/texturepackergui/utils/PaletteReducer.java
+++ b/core/src/com/crashinvaders/texturepackergui/utils/PaletteReducer.java
@@ -6,11 +6,12 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ByteArray;
 import com.badlogic.gdx.utils.IntIntMap;
-import com.badlogic.gdx.utils.SortedIntList;
+import com.badlogic.gdx.utils.NumberUtils;
 
-import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
+import java.util.Collections;
+import java.util.Comparator;
 
 /**
  * Data that can be used to limit the colors present in a Pixmap or other image, here with the goal of using 256 or less
@@ -22,12 +23,11 @@ public class PaletteReducer {
     public final byte[] paletteMapping = new byte[0x8000];
     public final int[] paletteArray = new int[256];
     ByteArray curErrorRedBytes, nextErrorRedBytes, curErrorGreenBytes, nextErrorGreenBytes, curErrorBlueBytes, nextErrorBlueBytes;
-
+    float ditherStrength = 0.5f, halfDitherStrength = 0.25f;
     /**
      * DawnBringer's 256-color Aurora palette, modified slightly to fit one transparent color by removing one gray.
      * Aurora is available in <a href="http://pixeljoint.com/forum/forum_posts.asp?TID=26080&KW=">this set of tools</a>
-     * for a pixel art editor, but it is usable for lots of high-color purposes. This is the default here, but that
-     * default value is not used (yet?).
+     * for a pixel art editor, but it is usable for lots of high-color purposes.
      */
     public static final int[] auroraPalette = {
             0x00000000, 0x010101FF, 0x131313FF, 0x252525FF, 0x373737FF, 0x494949FF, 0x5B5B5BFF, 0x6E6E6EFF,
@@ -67,100 +67,105 @@ public class PaletteReducer {
     /**
      * Constructs a default PaletteReducer that uses the DawnBringer Aurora palette.
      */
-    public PaletteReducer()
-    {
+    public PaletteReducer() {
         exact(auroraPalette);
     }
 
     /**
      * Constructs a PaletteReducer that uses the given array of RGBA8888 ints as a palette (see {@link #exact(int[])}
      * for more info).
+     *
      * @param rgbaPalette an array of RGBA8888 ints to use as a palette
      */
-    public PaletteReducer(int[] rgbaPalette)
-    {
+    public PaletteReducer(int[] rgbaPalette) {
         exact(rgbaPalette);
     }
+
     /**
      * Constructs a PaletteReducer that uses the given array of Color objects as a palette (see {@link #exact(Color[])}
      * for more info).
+     *
      * @param colorPalette an array of Color objects to use as a palette
      */
-    public PaletteReducer(Color[] colorPalette)
-    {
+    public PaletteReducer(Color[] colorPalette) {
         exact(colorPalette);
     }
+
     /**
      * Constructs a PaletteReducer that uses the given Array of Color objects as a palette (see {@link #exact(Color[])}
      * for more info).
+     *
      * @param colorPalette an array of Color objects to use as a palette
      */
-    public PaletteReducer(Array<Color> colorPalette)
-    {
-        if(colorPalette != null) 
+    public PaletteReducer(Array<Color> colorPalette) {
+        if (colorPalette != null)
             exact(colorPalette.items, colorPalette.size);
-        else 
+        else
             exact(auroraPalette);
     }
+
     /**
      * Constructs a PaletteReducer that analyzes the given Pixmap for color count and frequency to generate a palette
      * (see {@link #analyze(Pixmap)} for more info).
+     *
      * @param pixmap a Pixmap to analyze in detail to produce a palette
      */
-    public PaletteReducer(Pixmap pixmap)
-    {
+    public PaletteReducer(Pixmap pixmap) {
         analyze(pixmap);
     }
+
     /**
      * Constructs a PaletteReducer that analyzes the given Pixmap for color count and frequency to generate a palette
      * (see {@link #analyze(Pixmap, int)} for more info).
-     * @param pixmap a Pixmap to analyze in detail to produce a palette
+     *
+     * @param pixmap    a Pixmap to analyze in detail to produce a palette
      * @param threshold the minimum difference between colors required to put them in the palette (default 400)
      */
-    public PaletteReducer(Pixmap pixmap, int threshold)
-    {
+    public PaletteReducer(Pixmap pixmap, int threshold) {
         analyze(pixmap, threshold);
     }
 
     /**
      * Color difference metric; returns large numbers even for smallish differences.
      * If this returns 250 or more, the colors may be perceptibly different; 500 or more almost guarantees it.
+     *
      * @param color1 an RGBA8888 color as an int
      * @param color2 an RGBA8888 color as an int
      * @return the difference between the given colors, as a positive int
      */
-    public static int difference(final int color1, final int color2)
-    {
+    public static int difference(final int color1, final int color2) {
         int rmean = ((color1 >>> 24) + (color2 >>> 24)) >> 1;
         int r = (color1 >>> 24) - (color2 >>> 24);
-        int g = (color1 >>> 16 & 0xFF) - (color2 >>> 16 & 0xFF);
+        int g = (color1 >>> 16 & 0xFF) - (color2 >>> 16 & 0xFF) << 1;
         int b = (color1 >>> 8 & 0xFF) - (color2 >>> 8 & 0xFF);
-        return (((512+rmean)*r*r)>>8) + 4*g*g + (((767-rmean)*b*b)>>8);
-    }
-    /**
-     * Color difference metric; returns large numbers even for smallish differences.
-     * If this returns 250 or more, the colors may be perceptibly different; 500 or more almost guarantees it.
-     * @param color1 an RGBA8888 color as an int
-     * @param r2 red value from 0 to 255, inclusive
-     * @param g2 green value from 0 to 255, inclusive
-     * @param b2 blue value from 0 to 255, inclusive
-     * @return the difference between the given colors, as a positive int
-     */
-    public static int difference(final int color1, int r2, int g2, int b2)
-    {
-        r2 = (r2 << 3 | r2 >>> 2);
-        g2 = (g2 << 3 | g2 >>> 2);
-        b2 = (b2 << 3 | b2 >>> 2);
-        final int rmean = ((color1 >>> 24) + r2) >> 1,
-                r = (color1 >>> 24) - r2,
-                g = (color1 >>> 16 & 0xFF) - g2 << 1,
-                b = (color1 >>> 8 & 0xFF) - b2;
-        return (((512+rmean)*r*r)>>8) + g*g + (((767-rmean)*b*b)>>8);
+        return (((512 + rmean) * r * r) >> 8) + g * g + (((767 - rmean) * b * b) >> 8);
     }
 
     /**
      * Color difference metric; returns large numbers even for smallish differences.
      * If this returns 250 or more, the colors may be perceptibly different; 500 or more almost guarantees it.
+     *
+     * @param color1 an RGBA8888 color as an int
+     * @param r2     red value from 0 to 255, inclusive
+     * @param g2     green value from 0 to 255, inclusive
+     * @param b2     blue value from 0 to 255, inclusive
+     * @return the difference between the given colors, as a positive int
+     */
+    public static int difference(final int color1, int r2, int g2, int b2) {
+//        r2 = (r2 << 3 | r2 >>> 2);
+//        g2 = (g2 << 3 | g2 >>> 2);
+//        b2 = (b2 << 3 | b2 >>> 2);
+        final int rmean = ((color1 >>> 24) + r2) >> 1,
+                r = (color1 >>> 24) - r2,
+                g = (color1 >>> 16 & 0xFF) - g2 << 1,
+                b = (color1 >>> 8 & 0xFF) - b2;
+        return (((512 + rmean) * r * r) >> 8) + g * g + (((767 - rmean) * b * b) >> 8);
+    }
+
+    /**
+     * Color difference metric; returns large numbers even for smallish differences.
+     * If this returns 250 or more, the colors may be perceptibly different; 500 or more almost guarantees it.
+     *
      * @param r1 red value from 0 to 255, inclusive
      * @param r2 red value from 0 to 255, inclusive
      * @param g1 green value from 0 to 255, inclusive
@@ -169,25 +174,38 @@ public class PaletteReducer {
      * @param b2 blue value from 0 to 255, inclusive
      * @return the difference between the given colors, as a positive int
      */
-    public static int difference(final int r1, final int r2, final int g1, final int g2, final int b1, final int b2)
-    {
+    public static int difference(final int r1, final int r2, final int g1, final int g2, final int b1, final int b2) {
         final int rmean = (r1 + r2) >> 1,
                 r = r1 - r2,
                 g = g1 - g2 << 1,
                 b = b1 - b2;
-        return (((512+rmean)*r*r)>>8) + g*g + (((767-rmean)*b*b)>>8);
+        return (((512 + rmean) * r * r) >> 8) + g * g + (((767 - rmean) * b * b) >> 8);
     }
+
+    /**
+     * Gets a pseudo-random float between -0.3f and 0.7f, determined by the lower 23 bits and upper 2 bits of seed.
+     * The average value this returns will be less than 0f, despite its upper bound being further from 0 than its
+     * lower bound, because values between 0.2f and 0.7f are a third as likely to appear as values less than 0.125f,
+     * and even for values less than 0.2f, the range between -0.05f and 0.2f is a third as likely as the range from
+     * -0.3f to 0.05f. This introduced bias can be useful for adding some order to otherwise-random dithering.
+     * @param seed any int, but only the least-significant 23 bits will be used
+     * @return a float between -0.3f and 0.7f, weighted toward the lower end of the range
+     */
+    public static float randomXi(int seed)
+    {
+        return NumberUtils.intBitsToFloat((seed & 0x7FFFFF & ((seed >>> 11 & 0x600000)|0x1FFFFF)) | 0x3f800000) - 1.3f;
+    }
+
     /**
      * Builds the palette information this PNG8 stores from the RGBA8888 ints in {@code rgbaPalette}, up to 256 colors.
      * Alpha is not preserved except for the first item in rgbaPalette, and only if it is {@code 0} (fully transparent
      * black); otherwise all items are treated as opaque. If rgbaPalette is null, empty, or only has one color, then
      * this defaults to DawnBringer's Aurora palette with 256 hand-chosen colors (including transparent).
+     *
      * @param rgbaPalette an array of RGBA8888 ints; all will be used up to 256 items or the length of the array
      */
-    public void exact(int[] rgbaPalette)
-    {
-        if(rgbaPalette == null || rgbaPalette.length < 2)
-        {
+    public void exact(int[] rgbaPalette) {
+        if (rgbaPalette == null || rgbaPalette.length < 2) {
             rgbaPalette = auroraPalette;
         }
         Arrays.fill(paletteArray, 0);
@@ -200,16 +218,19 @@ public class PaletteReducer {
             paletteArray[i] = color;
             paletteMapping[(color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F)] = (byte) i;
         }
+        int rr, gg, bb;
         for (int r = 0; r < 32; r++) {
+            rr = (r << 3 | r >>> 2);
             for (int g = 0; g < 32; g++) {
+                gg = (g << 3 | g >>> 2);
                 for (int b = 0; b < 32; b++) {
                     c2 = r << 10 | g << 5 | b;
-                    if(paletteMapping[c2] == 0)
-                    {
+                    if (paletteMapping[c2] == 0) {
+                        bb = (b << 3 | b >>> 2);
                         dist = 0x7FFFFFFF;
-                        for (int i = 1; i < 256; i++) {
-                            if(dist > (dist = Math.min(dist, difference(paletteArray[i], r, g, b))))
-                                paletteMapping[c2] = (byte)i;
+                        for (int i = 1; i < plen; i++) {
+                            if (dist > (dist = Math.min(dist, difference(paletteArray[i], rr, gg, bb))))
+                                paletteMapping[c2] = (byte) i;
                         }
                     }
                 }
@@ -223,25 +244,25 @@ public class PaletteReducer {
      * 0f (fully transparent black); otherwise all items are treated as opaque. If rgbaPalette is null, empty, or only
      * has one color, then this defaults to DawnBringer's Aurora palette with 256 hand-chosen colors (including
      * transparent).
+     *
      * @param colorPalette an array of Color objects; all will be used up to 256 items or the length of the array
      */
-    public void exact(Color[] colorPalette)
-    {
+    public void exact(Color[] colorPalette) {
         exact(colorPalette, 256);
     }
+
     /**
      * Builds the palette information this PNG8 stores from the Color objects in {@code colorPalette}, up to 256 colors.
      * Alpha is not preserved except for the first item in colorPalette, and only if its r, g, b, and a values are all
      * 0f (fully transparent black); otherwise all items are treated as opaque. If rgbaPalette is null, empty, only has
      * one color, or limit is less than 2, then this defaults to DawnBringer's Aurora palette with 256 hand-chosen
      * colors (including transparent).
+     *
      * @param colorPalette an array of Color objects; all will be used up to 256 items, limit, or the length of the array
-     * @param limit a limit on how many Color items to use from colorPalette; useful if colorPalette is from an Array
+     * @param limit        a limit on how many Color items to use from colorPalette; useful if colorPalette is from an Array
      */
-    public void exact(Color[] colorPalette, int limit)
-    {
-        if(colorPalette == null || colorPalette.length < 2 || limit < 2)
-        {
+    public void exact(Color[] colorPalette, int limit) {
+        if (colorPalette == null || colorPalette.length < 2 || limit < 2) {
             exact(auroraPalette);
             return;
         }
@@ -255,23 +276,25 @@ public class PaletteReducer {
             paletteArray[i] = color;
             paletteMapping[(color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F)] = (byte) i;
         }
+        int rr, gg, bb;
         for (int r = 0; r < 32; r++) {
+            rr = (r << 3 | r >>> 2);
             for (int g = 0; g < 32; g++) {
+                gg = (g << 3 | g >>> 2);
                 for (int b = 0; b < 32; b++) {
                     c2 = r << 10 | g << 5 | b;
-                    if(paletteMapping[c2] == 0)
-                    {
+                    if (paletteMapping[c2] == 0) {
+                        bb = (b << 3 | b >>> 2);
                         dist = 0x7FFFFFFF;
-                        for (int i = 1; i < 256; i++) {
-                            if(dist > (dist = Math.min(dist, difference(paletteArray[i], r, g, b))))
-                                paletteMapping[c2] = (byte)i;
+                        for (int i = 1; i < plen; i++) {
+                            if (dist > (dist = Math.min(dist, difference(paletteArray[i], rr, gg, bb))))
+                                paletteMapping[c2] = (byte) i;
                         }
                     }
                 }
             }
         }
     }
-
     /**
      * Analyzes {@code pixmap} for color count and frequency, building a palette with at most 256 colors if there are
      * too many colors to store in a PNG-8 palette. If there are 256 or less colors, this uses the exact colors
@@ -284,11 +307,21 @@ public class PaletteReducer {
      * allowed in the palette, otherwise it is kept out for being too similar to existing colors. This doesn't return a
      * value but instead stores the palette info in this object; a PaletteReducer can be assigned to the
      * {@link PNG8#palette} field or can be used directly to {@link #reduce(Pixmap)} a Pixmap.
+     *
      * @param pixmap a Pixmap to analyze, making a palette which can be used by this to {@link #reduce(Pixmap)} or by PNG8
      */
     public void analyze(Pixmap pixmap) {
         analyze(pixmap, 400);
     }
+
+    private static final Comparator<IntIntMap.Entry> entryComparator = new Comparator<IntIntMap.Entry>() {
+        @Override
+        public int compare(IntIntMap.Entry o1, IntIntMap.Entry o2) {
+            return o2.value - o1.value;
+        }
+    };
+
+
     /**
      * Analyzes {@code pixmap} for color count and frequency, building a palette with at most 256 colors if there are
      * too many colors to store in a PNG-8 palette. If there are 256 or less colors, this uses the exact colors
@@ -302,154 +335,96 @@ public class PaletteReducer {
      * colors. The threshold is usually between 250 and 1000, and 400 is a good default. This doesn't return a value but
      * instead stores the palette info in this object; a PaletteReducer can be assigned to the {@link PNG8#palette}
      * field or can be used directly to {@link #reduce(Pixmap)} a Pixmap.
-     * @param pixmap a Pixmap to analyze, making a palette which can be used by this to {@link #reduce(Pixmap)} or by PNG8
+     *
+     * @param pixmap    a Pixmap to analyze, making a palette which can be used by this to {@link #reduce(Pixmap)} or by PNG8
      * @param threshold a minimum color difference as produced by {@link #difference(int, int)}; usually between 250 and 1000, 400 is a good default
      */
     public void analyze(Pixmap pixmap, int threshold) {
         Arrays.fill(paletteArray, 0);
         Arrays.fill(paletteMapping, (byte) 0);
         int color;
-        final ByteBuffer pixels = pixmap.getPixels();
+        final int width = pixmap.getWidth(), height = pixmap.getHeight();
         IntIntMap counts = new IntIntMap(256);
         int hasTransparent = 0;
         int[] reds = new int[256], greens = new int[256], blues = new int[256];
-        switch (pixmap.getFormat()) {
-            case RGBA8888: {
-                while (pixels.remaining() >= 4) {
-                    color = (pixels.getInt() & 0xF8F8F880);
-                    if ((color & 0x80) != 0) {
-                        color |= (color >>> 5 & 0x07070700) | 0xFE;
-                        counts.getAndIncrement(color, 0, 1);
-                    } else {
-                        hasTransparent = 1;
-                    }
-                }
-                if (counts.size + hasTransparent <= 256) {
-                    int i = hasTransparent;
-                    IntIntMap.Keys ks = counts.keys();
-                    while (ks.hasNext()) {
-                        color = ks.next();
-                        paletteArray[i] = color;
-                        color = (color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F);
-                        paletteMapping[color] = (byte) i;
-                        reds[i] = color >>> 10;
-                        greens[i] = color >>> 5 & 31;
-                        blues[i] = color & 31;
-                        i++;
-                    }
-                } else // reduce color count
-                {
-                    IntIntMap.Entries es = counts.entries();
-                    SortedIntList<IntIntMap.Entry> sil = new SortedIntList<>();
-                    while (es.hasNext()) {
-                        IntIntMap.Entry ent = es.next(), ent2 = new IntIntMap.Entry();
-                        ent2.key = ent.key;
-                        ent2.value = ent.value;
-                        sil.insert(-ent.value, ent2);
-                    }
-                    Iterator<SortedIntList.Node<IntIntMap.Entry>> it = sil.iterator();
-                    PER_BEST:
-                    for (int i = 1; i < 256 && it.hasNext(); ) {
-                        color = it.next().value.key;
-                        for (int j = 1; j < i; j++) {
-                            if (difference(color, paletteArray[j]) < threshold)
-                                continue PER_BEST;
-                        }
-                        paletteArray[i] = color;
-                        color = (color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F);
-                        paletteMapping[color] = (byte) i;
-                        reds[i] = color >>> 10;
-                        greens[i] = color >>> 5 & 31;
-                        blues[i] = color & 31;
-                        i++;
-                    }
-                }
-                int c2, dist;
-                for (int r = 0; r < 32; r++) {
-                    for (int g = 0; g < 32; g++) {
-                        for (int b = 0; b < 32; b++) {
-                            c2 = r << 10 | g << 5 | b;
-                            if (paletteMapping[c2] == 0) {
-                                dist = 0x7FFFFFFF;
-                                for (int i = 1; i < 256; i++) {
-                                    if (dist > (dist = Math.min(dist, difference(reds[i], r, greens[i], g, blues[i], b))))
-                                        paletteMapping[c2] = (byte) i;
-                                }
-                            }
-                        }
-                    }
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                color = pixmap.getPixel(x, y);
+                if ((color & 0x80) != 0) {
+                    color |= (color >>> 5 & 0x07070700) | 0xFE;
+                    counts.getAndIncrement(color, 0, 1);
+                } else {
+                    hasTransparent = 1;
                 }
             }
-            break;
-            case RGB888: {
-                while (pixels.remaining() >= 6) {
-                    color = (pixels.getInt() & 0xF8F8F800);
-                    color |= (color >>> 5 & 0x07070700) | 0xFE;
-                    pixels.position(pixels.position() - 1);
-                    counts.getAndIncrement(color, 0, 1);
+        }
+        final int cs = counts.size;
+        if (cs + hasTransparent <= 256) {
+            int i = hasTransparent;
+            for(IntIntMap.Entry e : counts) {
+                color = e.key;
+                paletteArray[i] = color;
+                color = (color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F);
+                paletteMapping[color] = (byte) i;
+                reds[i] = color >>> 10;
+                greens[i] = color >>> 5 & 31;
+                blues[i] = color & 31;
+                i++;
+            }
+        } else // reduce color count
+        {
+            ArrayList<IntIntMap.Entry> es = new ArrayList<>(cs);
+            for(IntIntMap.Entry e : counts)
+            {
+                IntIntMap.Entry e2 = new IntIntMap.Entry();
+                e2.key = e.key;
+                e2.value = e.value;
+                es.add(e2);
+            }
+            Collections.sort(es, entryComparator);
+            int i = 1, c = 0;
+            PER_BEST:
+            for (; i < 256 && c < cs;) {
+                color = es.get(c++).key;
+                for (int j = 1; j < i; j++) {
+                    if (difference(color, paletteArray[j]) < threshold)
+                        continue PER_BEST;
                 }
-                if (pixels.remaining() >= 3) {
-                    color = ((pixels.get() & 0xF8) << 24 | (pixels.get() & 0xF8) << 16 | (pixels.get() & 0xF8) << 8);
-                    color |= (color >>> 5 & 0x07070700) | 0xFE;
-                    counts.getAndIncrement(color, 0, 1);
-                }
-                if (counts.size <= 256) {
-                    int i = 0;
-                    IntIntMap.Keys ks = counts.keys();
-                    while (ks.hasNext()) {
-                        color = ks.next();
-                        paletteArray[i] = color;
-                        color = (color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F);
-                        paletteMapping[color] = (byte) i;
-                        reds[i] = color >>> 10;
-                        greens[i] = color >>> 5 & 31;
-                        blues[i] = color & 31;
-                        i++;
-                    }
-                } else {
-                    IntIntMap.Entries es = counts.entries();
-                    SortedIntList<IntIntMap.Entry> sil = new SortedIntList<>();
-                    while (es.hasNext()) {
-                        IntIntMap.Entry ent = es.next(), ent2 = new IntIntMap.Entry();
-                        ent2.key = ent.key;
-                        ent2.value = ent.value;
-                        sil.insert(-ent.value, ent2);
-                    }
-                    Iterator<SortedIntList.Node<IntIntMap.Entry>> it = sil.iterator();
-                    PER_BEST:
-                    for (int i = 1; i < 256 && it.hasNext(); ) {
-                        color = it.next().value.key;
-                        for (int j = 1; j < i; j++) {
-                            if (difference(color, paletteArray[j]) < threshold)
-                                continue PER_BEST;
-                        }
-                        paletteArray[i] = color;
-                        color = (color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F);
-                        paletteMapping[color] = (byte) i;
-                        reds[i] = color >>> 10;
-                        greens[i] = color >>> 5 & 31;
-                        blues[i] = color & 31;
-                        i++;
-                    }
-                }
-                int c2, dist;
-                for (int r = 0; r < 32; r++) {
-                    for (int g = 0; g < 32; g++) {
-                        for (int b = 0; b < 32; b++) {
-                            c2 = r << 10 | g << 5 | b;
-                            if (paletteMapping[c2] == 0) {
-                                dist = 0x7FFFFFFF;
-                                for (int i = 1; i < 256; i++) {
-                                    if (dist > (dist = Math.min(dist, difference(reds[i], r, greens[i], g, blues[i], b))))
-                                        paletteMapping[c2] = (byte) i;
-                                }
-                            }
+                paletteArray[i] = color;
+                color = (color >>> 17 & 0x7C00) | (color >>> 14 & 0x3E0) | (color >>> 11 & 0x1F);
+                paletteMapping[color] = (byte) i;
+                reds[i] = color >>> 10;
+                greens[i] = color >>> 5 & 31;
+                blues[i] = color & 31;
+                i++;
+            }
+        }
+        int c2, dist;
+        for (int r = 0; r < 32; r++) {
+            for (int g = 0; g < 32; g++) {
+                for (int b = 0; b < 32; b++) {
+                    c2 = r << 10 | g << 5 | b;
+                    if (paletteMapping[c2] == 0) {
+                        dist = 0x7FFFFFFF;
+                        for (int i = 1; i < 256; i++) {
+                            if (dist > (dist = Math.min(dist, difference(reds[i], r, greens[i], g, blues[i], b))))
+                                paletteMapping[c2] = (byte) i;
                         }
                     }
                 }
             }
         }
-        pixels.rewind();
+    }
+
+    /**
+     * Changes the "strength" of the dither effect applied during {@link #reduce(Pixmap)} calls. The default is 1f,
+     * and while both values higher than 1f and lower than 1f are valid, they should not be negative. If you want dither
+     * to be eliminated, don't set dither strength to 0; use {@link #reduceSolid(Pixmap)} instead of reduce().
+     * @param ditherStrength dither strength as a non-negative float that should be close to 1f
+     */
+    public void setDitherStrength(float ditherStrength) {
+        this.ditherStrength = 0.5f * ditherStrength;
+        this.halfDitherStrength = 0.25f * ditherStrength;
     }
 
     /**
@@ -526,24 +501,25 @@ public class PaletteReducer {
                     bdiff = (color>>>8&255)- (used>>>8&255);
                     if(px < lineLen - 1)
                     {
-                        curErrorRed[px+1]   += rdiff >> 1;
-                        curErrorGreen[px+1] += gdiff >> 1;
-                        curErrorBlue[px+1]  += bdiff >> 1;
+                        curErrorRed[px+1]   += rdiff * ditherStrength;
+                        curErrorGreen[px+1] += gdiff * ditherStrength;
+                        curErrorBlue[px+1]  += bdiff * ditherStrength;
                     }
                     if(ny < h)
                     {
                         if(px > 0)
                         {
-                            nextErrorRed[px-1]   += rdiff >> 2;
-                            nextErrorGreen[px-1] += gdiff >> 2;
-                            nextErrorBlue[px-1]  += bdiff >> 2;
+                            nextErrorRed[px-1]   += rdiff * halfDitherStrength;
+                            nextErrorGreen[px-1] += gdiff * halfDitherStrength;
+                            nextErrorBlue[px-1]  += bdiff * halfDitherStrength;
                         }
-                        nextErrorRed[px]   += rdiff >> 2;
-                        nextErrorGreen[px] += gdiff >> 2;
-                        nextErrorBlue[px]  += bdiff >> 2;
+                        nextErrorRed[px]   += rdiff * halfDitherStrength;
+                        nextErrorGreen[px] += gdiff * halfDitherStrength;
+                        nextErrorBlue[px]  += bdiff * halfDitherStrength;
                     }
                 }
             }
+
         }
         pixmap.setBlending(blending);
         return pixmap;
@@ -576,8 +552,287 @@ public class PaletteReducer {
                     int bb = ((color >>> 8)  & 0xFF);
                     pixmap.drawPixel(px, y, paletteArray[
                             paletteMapping[((rr << 7) & 0x7C00)
-                            | ((gg << 2) & 0x3E0)
-                            | ((bb >>> 3))] & 0xFF]);
+                                    | ((gg << 2) & 0x3E0)
+                                    | ((bb >>> 3))] & 0xFF]);
+                }
+            }
+
+        }
+        pixmap.setBlending(blending);
+        return pixmap;
+    }
+
+    /**
+     * Modifies the given Pixmap so it only uses colors present in this PaletteReducer, dithering when it can using
+     * Burkes dithering instead of the Sierra Lite dithering that {@link #reduce(Pixmap)} uses.
+     * If you want to reduce the colors in a Pixmap based on what it currently contains, call
+     * {@link #analyze(Pixmap)} with {@code pixmap} as its argument, then call this method with the same
+     * Pixmap. You may instead want to use a known palette instead of one computed from a Pixmap;
+     * {@link #exact(int[])} is the tool for that job.
+     * <br>
+     * This method is not incredibly fast because of the extra calculations it has to do for dithering, but if you can
+     * compute the PaletteReducer once and reuse it, that will save some time. Burkes dithering causes error to be
+     * propagated to more than twice as many pixels as Sierra Lite (7 instead of 3), but both only affect one row ahead
+     * of the pixel that is currently being dithered. For small images, the time spent dithering should be negligible.
+     * @param pixmap a Pixmap that will be modified in place
+     * @return the given Pixmap, for chaining
+     */
+    public Pixmap reduceBurkes (Pixmap pixmap) {
+        boolean hasTransparent = (paletteArray[0] == 0);
+        final int lineLen = pixmap.getWidth(), h = pixmap.getHeight();
+        float r4, r2, r1, g4, g2, g1, b4, b2, b1;
+        byte[] curErrorRed, nextErrorRed, curErrorGreen, nextErrorGreen, curErrorBlue, nextErrorBlue;
+        if (curErrorRedBytes == null) {
+            curErrorRed = (curErrorRedBytes = new ByteArray(lineLen)).items;
+            nextErrorRed = (nextErrorRedBytes = new ByteArray(lineLen)).items;
+            curErrorGreen = (curErrorGreenBytes = new ByteArray(lineLen)).items;
+            nextErrorGreen = (nextErrorGreenBytes = new ByteArray(lineLen)).items;
+            curErrorBlue = (curErrorBlueBytes = new ByteArray(lineLen)).items;
+            nextErrorBlue = (nextErrorBlueBytes = new ByteArray(lineLen)).items;
+        } else {
+            curErrorRed = curErrorRedBytes.ensureCapacity(lineLen);
+            nextErrorRed = nextErrorRedBytes.ensureCapacity(lineLen);
+            curErrorGreen = curErrorGreenBytes.ensureCapacity(lineLen);
+            nextErrorGreen = nextErrorGreenBytes.ensureCapacity(lineLen);
+            curErrorBlue = curErrorBlueBytes.ensureCapacity(lineLen);
+            nextErrorBlue = nextErrorBlueBytes.ensureCapacity(lineLen);
+            for (int i = 0; i < lineLen; i++) {
+                nextErrorRed[i] = 0;
+                nextErrorGreen[i] = 0;
+                nextErrorBlue[i] = 0;
+            }
+
+        }
+        Pixmap.Blending blending = pixmap.getBlending();
+        pixmap.setBlending(Pixmap.Blending.None);
+        int color, used, rdiff, gdiff, bdiff;
+        byte er, eg, eb, paletteIndex;
+        for (int y = 0; y < h; y++) {
+            int ny = y + 1;
+            for (int i = 0; i < lineLen; i++) {
+                curErrorRed[i] = nextErrorRed[i];
+                curErrorGreen[i] = nextErrorGreen[i];
+                curErrorBlue[i] = nextErrorBlue[i];
+                nextErrorRed[i] = 0;
+                nextErrorGreen[i] = 0;
+                nextErrorBlue[i] = 0;
+            }
+            for (int px = 0; px < lineLen; px++) {
+                color = pixmap.getPixel(px, y) & 0xF8F8F880;
+                if ((color & 0x80) == 0 && hasTransparent)
+                    pixmap.drawPixel(px, y, 0);
+                else {
+                    er = curErrorRed[px];
+                    eg = curErrorGreen[px];
+                    eb = curErrorBlue[px];
+                    color |= (color >>> 5 & 0x07070700) | 0xFE;
+                    int rr = MathUtils.clamp(((color >>> 24)       ) + (er), 0, 0xFF);
+                    int gg = MathUtils.clamp(((color >>> 16) & 0xFF) + (eg), 0, 0xFF);
+                    int bb = MathUtils.clamp(((color >>> 8)  & 0xFF) + (eb), 0, 0xFF);
+                    paletteIndex =
+                            paletteMapping[((rr << 7) & 0x7C00)
+                                    | ((gg << 2) & 0x3E0)
+                                    | ((bb >>> 3))];
+                    used = paletteArray[paletteIndex & 0xFF];
+                    pixmap.drawPixel(px, y, used);
+                    rdiff = (color>>>24)-    (used>>>24);
+                    gdiff = (color>>>16&255)-(used>>>16&255);
+                    bdiff = (color>>>8&255)- (used>>>8&255);
+                    r4 = rdiff * halfDitherStrength;
+                    g4 = gdiff * halfDitherStrength;
+                    b4 = bdiff * halfDitherStrength;
+                    r2 = r4 * 0.5f;
+                    g2 = g4 * 0.5f;
+                    b2 = b4 * 0.5f;
+                    r1 = r4 * 0.25f;
+                    g1 = g4 * 0.25f;
+                    b1 = b4 * 0.25f;
+                    if(px < lineLen - 1)
+                    {
+                        curErrorRed[px+1]   += r4;
+                        curErrorGreen[px+1] += g4;
+                        curErrorBlue[px+1]  += b4;
+                        if(px < lineLen - 2)
+                        {
+
+                            curErrorRed[px+2]   += r2;
+                            curErrorGreen[px+2] += g2;
+                            curErrorBlue[px+2]  += b2;
+                        }
+                    }
+                    if(ny < h)
+                    {
+                        if(px > 0)
+                        {
+                            nextErrorRed[px-1]   += r2;
+                            nextErrorGreen[px-1] += g2;
+                            nextErrorBlue[px-1]  += b2;
+                            if(px > 1)
+                            {
+                                nextErrorRed[px-2]   += r1;
+                                nextErrorGreen[px-2] += g1;
+                                nextErrorBlue[px-2]  += b1;
+                            }
+                        }
+                        nextErrorRed[px]   += r4;
+                        nextErrorGreen[px] += g4;
+                        nextErrorBlue[px]  += b4;
+                        if(px < lineLen - 1)
+                        {
+                            nextErrorRed[px+1]   += r2;
+                            nextErrorGreen[px+1] += g2;
+                            nextErrorBlue[px+1]  += b2;
+                            if(px < lineLen - 2)
+                            {
+
+                                nextErrorRed[px+2]   += r1;
+                                nextErrorGreen[px+2] += g1;
+                                nextErrorBlue[px+2]  += b1;
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+        pixmap.setBlending(blending);
+        return pixmap;
+    }
+
+    /**
+     * Modifies the given Pixmap so it only uses colors present in this PaletteReducer, dithering when it can using a
+     * modified version of the algorithm presented in "Simple gradient-based error-diffusion method" by Xaingyu Y. Hu in
+     * the Journal of Electronic Imaging, 2016. This algorithm uses pseudo-randomly-generated noise to adjust
+     * Floyd-Steinberg dithering, with input for the pseudo-random state obtained by the non-transparent color values as
+     * they are encountered. Very oddly, this tends to produce less random-seeming dither than
+     * {@link #reduceBurkes(Pixmap)}, with this method often returning regular checkerboards where Burkes may produce
+     * splotches of color. If you want to reduce the colors in a Pixmap based on what it currently contains, call
+     * {@link #analyze(Pixmap)} with {@code pixmap} as its argument, then call this method with the same
+     * Pixmap. You may instead want to use a known palette instead of one computed from a Pixmap;
+     * {@link #exact(int[])} is the tool for that job.
+     * <br>
+     * This method is not incredibly fast because of the extra calculations it has to do for dithering, but if you can
+     * compute the PaletteReducer once and reuse it, that will save some time. This method is probably slower than
+     * {@link #reduceBurkes(Pixmap)} even though Burkes propagates error to more pixels, because this method also has to
+     * generate two random values per non-transparent pixel. The random number "algorithm" this uses isn't very good
+     * because it doesn't have to be good, it should just be fast and avoid clear artifacts; it's similar to one of
+     * <a href="http://www.drdobbs.com/tools/fast-high-quality-parallel-random-number/231000484?pgno=2">Mark Overton's
+     * subcycle generators</a> (which are usually paired, but that isn't the case here), but because it's
+     * constantly being adjusted by additional colors as input, it may be more comparable to a rolling hash. This uses
+     * {@link #randomXi(int)} to get the parameter in Hu's paper that's marked as {@code aξ}, but our randomXi() is
+     * adjusted so it has a higher range into positive values but produces them less frequently than negative ones. That
+     * quirk ends up getting rather high quality for this method.
+     * @param pixmap a Pixmap that will be modified in place
+     * @return the given Pixmap, for chaining
+     */
+    public Pixmap reduceWithNoise (Pixmap pixmap) {
+        boolean hasTransparent = (paletteArray[0] == 0);
+        final int lineLen = pixmap.getWidth(), h = pixmap.getHeight();
+        byte[] curErrorRed, nextErrorRed, curErrorGreen, nextErrorGreen, curErrorBlue, nextErrorBlue;
+        if (curErrorRedBytes == null) {
+            curErrorRed = (curErrorRedBytes = new ByteArray(lineLen)).items;
+            nextErrorRed = (nextErrorRedBytes = new ByteArray(lineLen)).items;
+            curErrorGreen = (curErrorGreenBytes = new ByteArray(lineLen)).items;
+            nextErrorGreen = (nextErrorGreenBytes = new ByteArray(lineLen)).items;
+            curErrorBlue = (curErrorBlueBytes = new ByteArray(lineLen)).items;
+            nextErrorBlue = (nextErrorBlueBytes = new ByteArray(lineLen)).items;
+        } else {
+            curErrorRed = curErrorRedBytes.ensureCapacity(lineLen);
+            nextErrorRed = nextErrorRedBytes.ensureCapacity(lineLen);
+            curErrorGreen = curErrorGreenBytes.ensureCapacity(lineLen);
+            nextErrorGreen = nextErrorGreenBytes.ensureCapacity(lineLen);
+            curErrorBlue = curErrorBlueBytes.ensureCapacity(lineLen);
+            nextErrorBlue = nextErrorBlueBytes.ensureCapacity(lineLen);
+            for (int i = 0; i < lineLen; i++) {
+                nextErrorRed[i] = 0;
+                nextErrorGreen[i] = 0;
+                nextErrorBlue[i] = 0;
+            }
+
+        }
+        Pixmap.Blending blending = pixmap.getBlending();
+        pixmap.setBlending(Pixmap.Blending.None);
+        int color, used, rdiff, gdiff, bdiff, state = 0xFEEDBEEF;
+        byte er, eg, eb, paletteIndex;
+        //float xir1, xir2, xig1, xig2, xib1, xib2, // would be used if random factors were per-channel
+        // used now, where random factors are determined by whole colors as ints
+        float xi1, xi2, w1 = ditherStrength * 0.125f, w3 = w1 * 3f, w5 = w1 * 5f, w7 = w1 * 7f;
+        for (int y = 0; y < h; y++) {
+            int ny = y + 1;
+            for (int i = 0; i < lineLen; i++) {
+                curErrorRed[i] = nextErrorRed[i];
+                curErrorGreen[i] = nextErrorGreen[i];
+                curErrorBlue[i] = nextErrorBlue[i];
+                nextErrorRed[i] = 0;
+                nextErrorGreen[i] = 0;
+                nextErrorBlue[i] = 0;
+            }
+            for (int px = 0; px < lineLen; px++) {
+                color = pixmap.getPixel(px, y) & 0xF8F8F880;
+                if ((color & 0x80) == 0 && hasTransparent)
+                    pixmap.drawPixel(px, y, 0);
+                else {
+                    er = curErrorRed[px];
+                    eg = curErrorGreen[px];
+                    eb = curErrorBlue[px];
+                    color |= (color >>> 5 & 0x07070700) | 0xFE;
+                    int rr = MathUtils.clamp(((color >>> 24)       ) + (er), 0, 0xFF);
+                    int gg = MathUtils.clamp(((color >>> 16) & 0xFF) + (eg), 0, 0xFF);
+                    int bb = MathUtils.clamp(((color >>> 8)  & 0xFF) + (eb), 0, 0xFF);
+                    paletteIndex =
+                            paletteMapping[((rr << 7) & 0x7C00)
+                                    | ((gg << 2) & 0x3E0)
+                                    | ((bb >>> 3))];
+                    used = paletteArray[paletteIndex & 0xFF];
+                    pixmap.drawPixel(px, y, used);
+                    rdiff = (color>>>24)-    (used>>>24);
+                    gdiff = (color>>>16&255)-(used>>>16&255);
+                    bdiff = (color>>>8&255)- (used>>>8&255);
+                    state += (color + 0x41C64E6D) ^ color >>> 7;
+                    state = (state << 21 | state >>> 11);
+                    xi1 = randomXi(state);
+                    state = (state << 15 | state >>> 17) ^ 0x9E3779B9;
+                    xi2 = randomXi(state);
+
+//                    state += rdiff ^ rdiff << 9;
+//                    state = (state << 21 | state >>> 11);
+//                    xir1 = randomXi(state);
+//                    state = (state << 21 | state >>> 11);
+//                    xir2 = randomXi(state);
+//                    state += gdiff ^ gdiff << 9;
+//                    state = (state << 21 | state >>> 11);
+//                    xig1 = randomXi(state);
+//                    state = (state << 21 | state >>> 11);
+//                    xig2 = randomXi(state);
+//                    state += bdiff ^ bdiff << 9;
+//                    state = (state << 21 | state >>> 11);
+//                    xib1 = randomXi(state);
+//                    state = (state << 21 | state >>> 11);
+//                    xib2 = randomXi(state);
+                    if(px < lineLen - 1)
+                    {
+                        curErrorRed[px+1]   += rdiff * w7 * (1f + xi1);
+                        curErrorGreen[px+1] += gdiff * w7 * (1f + xi1);
+                        curErrorBlue[px+1]  += bdiff * w7 * (1f + xi1);
+                    }
+                    if(ny < h)
+                    {
+                        if(px > 0)
+                        {
+                            nextErrorRed[px-1]   += rdiff * w3 * (1f + xi2);
+                            nextErrorGreen[px-1] += gdiff * w3 * (1f + xi2);
+                            nextErrorBlue[px-1]  += bdiff * w3 * (1f + xi2);
+                        }
+                        if(px < lineLen - 1)
+                        {
+                            nextErrorRed[px+1]   += rdiff * w1 * (1f - xi2);
+                            nextErrorGreen[px+1] += gdiff * w1 * (1f - xi2);
+                            nextErrorBlue[px+1]  += bdiff * w1 * (1f - xi2);
+                        }
+                        nextErrorRed[px]   += rdiff * w5 * (1f - xi1);
+                        nextErrorGreen[px] += gdiff * w5 * (1f - xi1);
+                        nextErrorBlue[px]  += bdiff * w5 * (1f - xi1);
+                    }
                 }
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx1500m
-org.gradle.configureondemand=true
+org.gradle.configureondemand=false
 
 gdxVersion=1.9.8
 lmlVersion=1.9.1.9.8-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip


### PR DESCRIPTION
This PR fixes a bug in PaletteReducer where one or more colors could be omitted because they appeared the same number of times as another color. It changes the default dithering to a semi-random dither because it seems to yield better, more natural results. Most importantly, it defaults to trying to preserve colors exactly if there are 256 or less of them, falling back to using the dithering and analysis threshold settings. There's also some small build configuration changes that I needed to be able to build the project (the `secret/` folder is a minor issue when building a freshly-checked-out clone of the repo).