### PR TITLE
Linking project overview dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ All major changes are listed in [this file](https://github.com/crashinvaders/gdx
 Any contribution is highly appreciated. You can help either by making PR or reporting bugs/suggestions by creating new issues.
 If you have any questions or ideas and you think they don't fit standard GitHub issue format, you always welcome to contact me directly at anton@crashinvaders.com
 
+This dashboard describes [project structure and dependencies](https://sourcespy.com/github/crashinvadersgdxtexturepackergui/). New contributors can quickly grasp overall structure of the code and technologies involved.
+
 Also you can participate in translation. It can be done by translating all the strings in [bundle.properties](https://github.com/crashinvaders/gdx-texture-packer-gui/blob/master/assets/i18n/bundle.properties) and saving copy as bundle_XX.properties, where XX is your language code.
 
 ### Story behind


### PR DESCRIPTION
Adding a link to the README. Dashboard describes overall project structure and dependencies. Will be useful for new developers looking to contribute to the project. Direct link: https://sourcespy.com/github/crashinvadersgdxtexturepackergui/