### PR TITLE
Update libGDX to 1.9.13, visUI to 1.4.8, anim8-gdx to 0.2.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@
 - Fixed KTX(ETC1/ETC2) compression fails with NPE.
 - Old PNG8 compression is replaced with anim8-gdx implementation (https://github.com/tommyettinger/anim8-gdx).
 - General project save/load errors now gracefully handled and crash log is available.
+- Updated to libGDX 1.9.13, which enables the much-smaller new atlas format.
+- Updated to visUI 1.4.8.
 
 [4.9.0]
 - JRE 8+ is required to run the app.

--- a/core/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/core/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -700,8 +700,8 @@ public class TexturePacker {
 		public String[] scaleSuffix = {""};
 		public Resampling[] scaleResampling = {Resampling.bicubic};
 		public String atlasExtension = ".atlas";
-		public boolean prettyPrint = false;
-		public boolean legacyOutput = false;
+		public boolean prettyPrint = false; //TODO: does this need a UI setting?
+		public boolean legacyOutput = false; //TODO: this needs a UI setting.
 
 		public Settings () {
 		}

--- a/core/src/com/badlogic/gdx/tools/texturepacker/TextureUnpacker.java
+++ b/core/src/com/badlogic/gdx/tools/texturepacker/TextureUnpacker.java
@@ -94,7 +94,7 @@ public class TextureUnpacker {
 					String extension = null;
 
 					// check if the region is a ninepatch or a normal image and delegate accordingly
-					if (region.splits == null) {
+					if (region.findValue("split") == null) {
 						splitImage = extractImage(img, region, outputDirFile, 0);
 						if (region.width != region.originalWidth || region.height != region.originalHeight) {
 							BufferedImage originalImg = new BufferedImage(region.originalWidth, region.originalHeight, img.getType());
@@ -110,7 +110,8 @@ public class TextureUnpacker {
 					}
 
 					// check if the parent directories of this image file exist and create them if not
-					File imgOutput = new File(outputDirFile, String.format("%s.%s", region.index == -1?region.name:region.name + "_" + region.index, extension));
+					File imgOutput = new File(outputDirFile,
+							String.format("%s.%s", region.index == -1 ? region.name : region.name + "_" + region.index, extension));
 					File imgDir = imgOutput.getParentFile();
 					if (!imgDir.exists()) {
 						System.out.println(String.format("Creating directory: %s", imgDir.getPath()));
@@ -120,7 +121,7 @@ public class TextureUnpacker {
 					// save the image
 					try {
 						ImageIO.write(splitImage, OUTPUT_TYPE, imgOutput);
-					} catch (IOException e) {
+					} catch (Exception e) {
 						printExceptionAndExit(e);
 					}
 				}
@@ -154,7 +155,7 @@ public class TextureUnpacker {
 		// draw the image to a bigger one if padding is needed
 		if (padding > 0) {
 			BufferedImage paddedImage = new BufferedImage(splitImage.getWidth() + padding * 2, splitImage.getHeight() + padding * 2,
-				page.getType());
+					page.getType());
 			Graphics2D g2 = paddedImage.createGraphics();
 			g2.drawImage(splitImage, padding, padding, null);
 			g2.dispose();
@@ -174,17 +175,19 @@ public class TextureUnpacker {
 		g2.setColor(Color.BLACK);
 
 		// Draw the four lines to save the ninepatch's padding and splits
-		int startX = region.splits[0] + NINEPATCH_PADDING;
-		int endX = region.width - region.splits[1] + NINEPATCH_PADDING - 1;
-		int startY = region.splits[2] + NINEPATCH_PADDING;
-		int endY = region.height - region.splits[3] + NINEPATCH_PADDING - 1;
+		int[] splits = region.findValue("split");
+		int startX = splits[0] + NINEPATCH_PADDING;
+		int endX = region.width - splits[1] + NINEPATCH_PADDING - 1;
+		int startY = splits[2] + NINEPATCH_PADDING;
+		int endY = region.height - splits[3] + NINEPATCH_PADDING - 1;
 		if (endX >= startX) g2.drawLine(startX, 0, endX, 0);
 		if (endY >= startY) g2.drawLine(0, startY, 0, endY);
-		if (region.pads != null) {
-			int padStartX = region.pads[0] + NINEPATCH_PADDING;
-			int padEndX = region.width - region.pads[1] + NINEPATCH_PADDING - 1;
-			int padStartY = region.pads[2] + NINEPATCH_PADDING;
-			int padEndY = region.height - region.pads[3] + NINEPATCH_PADDING - 1;
+		int[] pads = region.findValue("pad");
+		if (pads != null) {
+			int padStartX = pads[0] + NINEPATCH_PADDING;
+			int padEndX = region.width - pads[1] + NINEPATCH_PADDING - 1;
+			int padStartY = pads[2] + NINEPATCH_PADDING;
+			int padEndY = region.height - pads[3] + NINEPATCH_PADDING - 1;
 			g2.drawLine(padStartX, splitImage.getHeight() - 1, padEndX, splitImage.getHeight() - 1);
 			g2.drawLine(splitImage.getWidth() - 1, padStartY, splitImage.getWidth() - 1, padEndY);
 		}

--- a/core/src/com/crashinvaders/common/PrioritizedInputMultiplexer.java
+++ b/core/src/com/crashinvaders/common/PrioritizedInputMultiplexer.java
@@ -100,10 +100,10 @@ public class PrioritizedInputMultiplexer implements InputProcessor {
 		return false;
 	}
 
-	@Override
-	public boolean scrolled (int amount) {
+    @Override
+    public boolean scrolled(float amountX, float amountY) {
 		for (int i = 0, n = processors.size(); i < n; i++)
-			if (processors.getValueAt(i).scrolled(amount)) return true;
+			if (processors.getValueAt(i).scrolled(amountX, amountY)) return true;
 		return false;
 	}
 
@@ -144,8 +144,8 @@ public class PrioritizedInputMultiplexer implements InputProcessor {
             return processor.mouseMoved(screenX, screenY);
         }
         @Override
-        public boolean scrolled(int amount) {
-            return processor.scrolled(amount);
+        public boolean scrolled(float amountX, float amountY) {
+            return processor.scrolled(amountX, amountY);
         }
 
         @Override

--- a/core/src/com/crashinvaders/texturepackergui/controllers/main/MainController.java
+++ b/core/src/com/crashinvaders/texturepackergui/controllers/main/MainController.java
@@ -666,7 +666,7 @@ public class MainController implements ActionContainer, ViewShower, ViewResizer 
             menuItem.setShortcut(CommonUtils.ellipsize(file.path(), 72)); // Will use shortcut label to display file path
             menuItem.getShortcutCell().left().expandX();
             menuItem.getLabelCell().expand(false, false).left();
-            menuItem.getImageCell().width(0); // Shrink image cell to zero, we don't need it
+//            menuItem.getImageCell().width(0); // Shrink image cell to zero, we don't need it
             menuItem.pack();
             menuItem.addListener(new ChangeListener() {
                 @Override

--- a/core/src/com/crashinvaders/texturepackergui/controllers/ninepatcheditor/CompositionHolder.java
+++ b/core/src/com/crashinvaders/texturepackergui/controllers/ninepatcheditor/CompositionHolder.java
@@ -191,7 +191,7 @@ class CompositionHolder extends WidgetGroup {
 
     private class ZoomListener extends InputListener {
         @Override
-        public boolean scrolled(InputEvent event, float x, float y, int amount) {
+        public boolean scrolled(InputEvent event, float x, float y, float amountX, float amountY) {
 
             float preWidth = sourceImage.getPrefWidth();
             float preHeight = sourceImage.getPrefHeight();
@@ -203,7 +203,7 @@ class CompositionHolder extends WidgetGroup {
             }
 
             int zoomIndex = model.zoomModel.getIndex();
-            model.zoomModel.setIndex(zoomIndex - amount);
+            model.zoomModel.setIndex((int) (zoomIndex - amountY));
 
             float postWidth = sourceImage.getPrefWidth();
             float postHeight = sourceImage.getPrefHeight();

--- a/core/src/com/crashinvaders/texturepackergui/controllers/ninepatcheditor/NinePatchEditorDialog.java
+++ b/core/src/com/crashinvaders/texturepackergui/controllers/ninepatcheditor/NinePatchEditorDialog.java
@@ -116,9 +116,9 @@ public class NinePatchEditorDialog implements ActionContainer {
         });
         spPreview.addListener(new InputListener() {
             @Override
-            public boolean scrolled(InputEvent event, float x, float y, int amount) {
+            public boolean scrolled(InputEvent event, float x, float y, float amountX, float amountY) {
                 int zoomIndex = model.zoomModel.getIndex();
-                model.zoomModel.setIndex(zoomIndex - amount);
+                model.zoomModel.setIndex((int) (zoomIndex - amountY));
                 return true;
             }
         });

--- a/core/src/com/crashinvaders/texturepackergui/views/canvas/widgets/preview/PreviewHolder.java
+++ b/core/src/com/crashinvaders/texturepackergui/views/canvas/widgets/preview/PreviewHolder.java
@@ -201,7 +201,7 @@ public class PreviewHolder extends WidgetGroup {
         }
 
         @Override
-        public boolean scrolled(InputEvent event, float x, float y, int amount) {
+        public boolean scrolled (InputEvent event, float x, float y, float amountX, float amountY) {
             if (pageGroup == null) return false;
 
             float preWidth = pageGroup.getWidth() * pageGroup.getScaleX();
@@ -209,7 +209,7 @@ public class PreviewHolder extends WidgetGroup {
             float xNormalized = x < pageGroup.getX() ? 0f : x > pageGroup.getX()+preWidth ? 1f : (x- pageGroup.getX())/preWidth;
             float yNormalized = y < pageGroup.getY() ? 0f : y > pageGroup.getY()+preHeight ? 1f : (y- pageGroup.getY())/preHeight;
 
-            setZoomIndex(Math.max(0, Math.min(ZOOM_LEVELS.length-1, zoomIndex - amount)));
+            setZoomIndex(Math.max(0, Math.min(ZOOM_LEVELS.length-1, (int) (zoomIndex - amountY))));
 
             float postWidth = pageGroup.getWidth() * pageGroup.getScaleX();
             float postHeight = pageGroup.getHeight() * pageGroup.getScaleY();

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx1500m
 org.gradle.configureondemand=false
 
-gdxVersion=1.9.11
+gdxVersion=1.9.13
 lmlVersion=1.9.1.9.11-SNAPSHOT
 visUiVersion=1.4.6
 args4jVersion=2.33
@@ -10,4 +10,4 @@ commonsIoVersion=2.6
 pngtasticVersion=1.6
 tinifyVersion=1.6.4
 scribeJavaVersion=6.9.0
-anim8Version=0.2.2
+anim8Version=0.2.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,9 @@ org.gradle.configureondemand=false
 
 gdxVersion=1.9.13
 lmlVersion=1.9.1.9.11-SNAPSHOT
-visUiVersion=1.4.6
+visUiVersion=1.4.8
 args4jVersion=2.33
 commonsIoVersion=2.6
 pngtasticVersion=1.6
 tinifyVersion=1.6.4
-scribeJavaVersion=6.9.0
-anim8Version=0.2.4
+anim8Version=0.2.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Using libGDX 1.9.13 brings much smaller file sizes for the biggest atlases, but required updating through 1.9.12 first, which had some changes needed (InputProcessor.scrolled() changed). Also, Gradle is updated to 6.7.1 (so Java 15 can be used to import the project), visUI is updated to 1.4.8 (which improves compatibility with libGDX 1.9.12, where most of the breaking changes were) and anim8-gdx is updated to 0.2.5 (no API changes that affect this repo, but better color sensitivity). There's some incompatibility between VisUI and libGDX 1.9.13; a MenuItem throws an exception that I addressed before updating to 1.4.8. I don't think 1.4.8 fixed that exception, because it happened again in pure-visUI code for the file picker after updating, and there's not much I can do about bugs in visUI.

**HOWEVER**, this may need some changes before it can be used in this repo. I don't know how to add settings to the GUI yet, and 1.9.13 adds a `legacyOutput` setting and a `prettyPrint` setting. I defaulted both to false here (lines 703 and 704 of TexturePacker.java), but there should probably be some config in case users want the larger but backwards-compatible atlases. If these two settings are both always false, this will only output atlases that can be read by 1.9.13 and newer, though they will be smaller files.

I may have messed up something during the update; TexturePacker here had some changes that didn't match up to libGDX's version. I think it works OK though; I generated the atlases in https://github.com/tommyettinger/DawnLikeAtlas/tree/master/thirteen with this version of the packer GUI.