### PR TITLE
Change project and atlas menu Alt keys

### DIFF
--- a/assets/hotkeys_default.txt
+++ b/assets/hotkeys_default.txt
@@ -38,7 +38,7 @@ packSelectedAtlas: CTRL+P
 packMultipleAtlases: CTRL+SHIFT+P
 packAllAtlases: CTRL+ALT+SHIFT+P
 
-showMenuProject: ALT+F
-showMenuAtlas: ALT+P
+showMenuProject: ALT+P
+showMenuAtlas: ALT+A
 showMenuTools: ALT+T
 showMenuHelp: ALT+H


### PR DESCRIPTION
The existing keys are confusing and seem like they may have not been updated at some point during development, as if the menu options used to be File, Project. Nowhere in the word "Project" is the letter F.