### PR TITLE
Fix offsetY value when write pack file with setting `Strip Whitespace Y` checked

### DIFF
--- a/core/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/core/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -437,11 +437,10 @@ public class TexturePacker {
 				+ (page.x + rect.x) + comma + (page.y + page.height - rect.y - (rect.height - settings.paddingY)) + comma //
 				+ rect.regionWidth + comma + rect.regionHeight + "\n");
 
-		int offsetY = rect.originalHeight - rect.regionHeight - rect.offsetY;
-		if (rect.offsetX != 0 || offsetY != 0 //
+		if (rect.offsetX != 0 || rect.offsetY != 0 //
 				|| rect.originalWidth != rect.regionWidth || rect.originalHeight != rect.regionHeight) {
 			writer.write(tab + "offsets" + colon //
-					+ rect.offsetX + comma + offsetY + comma //
+					+ rect.offsetX + comma + rect.offsetY + comma //
 					+ rect.originalWidth + comma + rect.originalHeight + "\n");
 		}
 
@@ -485,7 +484,7 @@ public class TexturePacker {
 			writer.write("  pad: " + rect.pads[0] + ", " + rect.pads[1] + ", " + rect.pads[2] + ", " + rect.pads[3] + "\n");
 		}
 		writer.write("  orig: " + rect.originalWidth + ", " + rect.originalHeight + "\n");
-		writer.write("  offset: " + rect.offsetX + ", " + (rect.originalHeight - rect.regionHeight - rect.offsetY) + "\n");
+		writer.write("  offset: " + rect.offsetX + ", " + rect.offsetY + "\n");
 		writer.write("  index: " + rect.index + "\n");
 	}
 


### PR DESCRIPTION
Expected rendered result:
![ezgif-1-462241e23b](https://github.com/user-attachments/assets/0f7fec0c-2e89-43cb-987d-80c846f95081)

Actual rendered result:
![ezgif-1-9aa3acb385](https://github.com/user-attachments/assets/1e80dc6d-35fe-4805-a409-0fb0281b7739)
